### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Debug Image: default image, which will be used for ephemeral containers and debu
 | ------ | ------ | ------|
 | busybox | Default value | https://hub.docker.com/_/busybox |
 | markeijsermans/debug |  | https://hub.docker.com/r/markeijsermans/debug |
-| wbitt/network-multitool | https://github.com/wbitt/Network-MultiTool |
+| wbitt/network-multitool | | https://github.com/wbitt/Network-MultiTool |
 
 Show all debug images in context menu: shows all debug images as context menu for operation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Debug Image: default image, which will be used for ephemeral containers and debu
 | ------ | ------ | ------|
 | busybox | Default value | https://hub.docker.com/_/busybox |
 | markeijsermans/debug |  | https://hub.docker.com/r/markeijsermans/debug |
-| wbitt/network-multitool | | https://github.com/wbitt/Network-MultiTool |
+| wbitt/network-multitool |  | https://github.com/wbitt/Network-MultiTool |
 
 Show all debug images in context menu: shows all debug images as context menu for operation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Debug Image: default image, which will be used for ephemeral containers and debu
 | ------ | ------ | ------|
 | busybox | Default value | https://hub.docker.com/_/busybox |
 | markeijsermans/debug |  | https://hub.docker.com/r/markeijsermans/debug |
-| praqma/network-multitool |  | https://hub.docker.com/r/praqma/network-multitool |
+| wbitt/network-multitool | https://github.com/wbitt/Network-MultiTool |
 
 Show all debug images in context menu: shows all debug images as context menu for operation
 


### PR DESCRIPTION
https://hub.docker.com/r/praqma/network-multitool was taken over by https://hub.docker.com/r/wbitt/network-multitool due the company name change.

> Few years ago, I created this tool with Henrik Høegh, as praqma/network-multitool. Praqma was bought by another company, and now the "Praqma" brand is being dismantled. This means the network-multitool's git and docker repositories must go. Since, I was the one maintaining the docker image for all these years, it was decided by the current representatives of the company to hand it over to me so I can continue maintaining it. So, apart from a small change in the repository name/url, nothing has changed.